### PR TITLE
Harden xcb-based bindings to remove some autocasts

### DIFF
--- a/modules/Linux_Display/ld_xcb.jai
+++ b/modules/Linux_Display/ld_xcb.jai
@@ -113,13 +113,13 @@ xcb_init_display :: (display: *Display) -> bool {
     map_parts := xcb_xkb_map_part_t.KEY_TYPES | .KEY_SYMS | .MODIFIER_MAP | .EXPLICIT_COMPONENTS | .KEY_ACTIONS | .VIRTUAL_MODS | .VIRTUAL_MOD_MAP;
     state_parts := xcb_xkb_state_part_t.MODIFIER_BASE | .MODIFIER_LATCH | .MODIFIER_LOCK | .GROUP_BASE | .GROUP_LATCH | .GROUP_LOCK;
     details := xcb_xkb_select_events_details_t.{
-        affectNewKeyboard = xx xcb_xkb_nkn_detail_t.KEYCODES,
-        newKeyboardDetails = xx xcb_xkb_nkn_detail_t.KEYCODES,
-        affectState = xx state_parts,
-        stateDetails = xx state_parts,
+        affectNewKeyboard = .KEYCODES,
+        newKeyboardDetails = .KEYCODES,
+        affectState = state_parts,
+        stateDetails = state_parts,
     };
     core := xkb_x11_get_core_keyboard_device_id(connection);
-    xcb_xkb.select_events_aux(connection, xx core, xx affect, 0, 0, xx map_parts, xx map_parts, *details);
+    xcb_xkb.select_events_aux(connection, xx core, affect, 0, 0, map_parts, map_parts, *details);
 
     atom_names: Table(xcb_atom_t, string);
     {
@@ -212,7 +212,7 @@ xcb_create_window :: (display: *Display, window: *Window, width: int, height: in
 
     xcb.change_property(
         xd.handle,
-        xx xcb_prop_mode_t.REPLACE,
+        .REPLACE,
         wid,
         xd.global_atoms.WM_PROTOCOLS,
         xx xcb_atom_enum_t.ATOM,
@@ -419,14 +419,14 @@ xcb_set_icon_from_raw_data :: (window: *Window, data: *u8, width: u32, height: u
     size_data := u32.[width, height];
     xcb.change_property(
         xd.handle,
-        xx xcb_prop_mode_t.REPLACE,
+        .REPLACE,
         xw.handle,
         xd.global_atoms._NET_WM_ICON,
         xx xcb_atom_enum_t.CARDINAL,
         32, xx size_data.count, size_data.data);
     xcb.change_property(
         xd.handle,
-        xx xcb_prop_mode_t.APPEND,
+        .APPEND,
         xw.handle,
         xd.global_atoms._NET_WM_ICON,
         xx xcb_atom_enum_t.CARDINAL,
@@ -498,7 +498,7 @@ xcb_set_cursor_from_theme :: (window: *Window, name: string) {
     if found {
         attrs: xcb_change_window_attributes_value_list_t;
         attrs.cursor = cursor;
-        xcb.change_window_attributes_aux(xd.handle, xw.handle, xx xcb_cw_t.CURSOR, *attrs);
+        xcb.change_window_attributes_aux(xd.handle, xw.handle, .CURSOR, *attrs);
     }
 }
 
@@ -859,10 +859,10 @@ set_utf8_property :: (xw: *XCB_Window, property: xcb_atom_t, value: string) {
     sz_val := tprint("%\0", value);
     xcb.change_property(
         xd.handle,
-        xx xcb_prop_mode_t.REPLACE,
+        .REPLACE,
         xw.handle,
-        xx property,
-        xx xd.global_atoms.UTF8_STRING,
+        property,
+        xd.global_atoms.UTF8_STRING,
         8, xx sz_val.count, sz_val.data);
 }
 

--- a/modules/Linux_Display/xcb_fp.jai
+++ b/modules/Linux_Display/xcb_fp.jai
@@ -1694,7 +1694,7 @@ xcb_change_window_attributes_request_t :: struct {
     pad0:         u8;
     length:       u16;
     window:       xcb_window_t;
-    value_mask:   u32;
+    value_mask:   xcb_cw_t;
 }
 
 xcb_map_state_t :: enum u32 {
@@ -1960,7 +1960,7 @@ xcb_get_atom_name_reply_t :: struct {
     pad1:          [22] u8;
 }
 
-xcb_prop_mode_t :: enum u32 {
+xcb_prop_mode_t :: enum u8 {
     REPLACE :: 0;
     PREPEND :: 1;
     APPEND  :: 2;
@@ -1972,7 +1972,7 @@ xcb_prop_mode_t :: enum u32 {
 
 xcb_change_property_request_t :: struct {
     major_opcode: u8;
-    mode:         u8;
+    mode:         xcb_prop_mode_t;
     length:       u16;
     window:       xcb_window_t;
     property:     xcb_atom_t;
@@ -4127,10 +4127,10 @@ XCB_Symbols :: struct #type_info_procedures_are_void_pointers #type_info_no_size
     change_window_attributes_value_list_unpack:       #type (_buffer: *void, value_mask: u32, _aux: *xcb_change_window_attributes_value_list_t) -> s32 #c_call;
     change_window_attributes_value_list_sizeof:       #type (_buffer: *void, value_mask: u32) -> s32 #c_call;
     change_window_attributes_sizeof:                  #type (_buffer: *void) -> s32 #c_call;
-    change_window_attributes_checked:                 #type (c: *xcb_connection_t, window: xcb_window_t, value_mask: u32, value_list: *void) -> xcb_void_cookie_t #c_call;
-    change_window_attributes:                         #type (c: *xcb_connection_t, window: xcb_window_t, value_mask: u32, value_list: *void) -> xcb_void_cookie_t #c_call;
-    change_window_attributes_aux_checked:             #type (c: *xcb_connection_t, window: xcb_window_t, value_mask: u32, value_list: *xcb_change_window_attributes_value_list_t) -> xcb_void_cookie_t #c_call;
-    change_window_attributes_aux:                     #type (c: *xcb_connection_t, window: xcb_window_t, value_mask: u32, value_list: *xcb_change_window_attributes_value_list_t) -> xcb_void_cookie_t #c_call;
+    change_window_attributes_checked:                 #type (c: *xcb_connection_t, window: xcb_window_t, value_mask: xcb_cw_t, value_list: *void) -> xcb_void_cookie_t #c_call;
+    change_window_attributes:                         #type (c: *xcb_connection_t, window: xcb_window_t, value_mask: xcb_cw_t, value_list: *void) -> xcb_void_cookie_t #c_call;
+    change_window_attributes_aux_checked:             #type (c: *xcb_connection_t, window: xcb_window_t, value_mask: xcb_cw_t, value_list: *xcb_change_window_attributes_value_list_t) -> xcb_void_cookie_t #c_call;
+    change_window_attributes_aux:                     #type (c: *xcb_connection_t, window: xcb_window_t, value_mask: xcb_cw_t, value_list: *xcb_change_window_attributes_value_list_t) -> xcb_void_cookie_t #c_call;
     change_window_attributes_value_list:              #type (R: *xcb_change_window_attributes_request_t) -> *void #c_call;
     get_window_attributes:                            #type (c: *xcb_connection_t, window: xcb_window_t) -> xcb_get_window_attributes_cookie_t #c_call;
     get_window_attributes_unchecked:                  #type (c: *xcb_connection_t, window: xcb_window_t) -> xcb_get_window_attributes_cookie_t #c_call;
@@ -4184,8 +4184,8 @@ XCB_Symbols :: struct #type_info_procedures_are_void_pointers #type_info_no_size
     get_atom_name_name_end:                           #type (R: *xcb_get_atom_name_reply_t) -> xcb_generic_iterator_t #c_call;
     get_atom_name_reply:                              #type (c: *xcb_connection_t, cookie: xcb_get_atom_name_cookie_t, e: **xcb_generic_error_t) -> *xcb_get_atom_name_reply_t #c_call;
     change_property_sizeof:                           #type (_buffer: *void) -> s32 #c_call;
-    change_property_checked:                          #type (c: *xcb_connection_t, mode: u8, window: xcb_window_t, property: xcb_atom_t, type: xcb_atom_t, format: u8, data_len: u32, data: *void) -> xcb_void_cookie_t #c_call;
-    change_property:                                  #type (c: *xcb_connection_t, mode: u8, window: xcb_window_t, property: xcb_atom_t, type: xcb_atom_t, format: u8, data_len: u32, data: *void) -> xcb_void_cookie_t #c_call;
+    change_property_checked:                          #type (c: *xcb_connection_t, mode: xcb_prop_mode_t, window: xcb_window_t, property: xcb_atom_t, type: xcb_atom_t, format: u8, data_len: u32, data: *void) -> xcb_void_cookie_t #c_call;
+    change_property:                                  #type (c: *xcb_connection_t, mode: xcb_prop_mode_t, window: xcb_window_t, property: xcb_atom_t, type: xcb_atom_t, format: u8, data_len: u32, data: *void) -> xcb_void_cookie_t #c_call;
     change_property_data:                             #type (R: *xcb_change_property_request_t) -> *void #c_call;
     change_property_data_length:                      #type (R: *xcb_change_property_request_t) -> s32 #c_call;
     change_property_data_end:                         #type (R: *xcb_change_property_request_t) -> xcb_generic_iterator_t #c_call;

--- a/modules/Linux_Display/xcb_xkb_fp.jai
+++ b/modules/Linux_Display/xcb_xkb_fp.jai
@@ -121,7 +121,7 @@ xcb_xkb_event_type_t :: enum u32 {
     XCB_XKB_EVENT_TYPE_EXTENSION_DEVICE_NOTIFY :: EXTENSION_DEVICE_NOTIFY;
 }
 
-xcb_xkb_nkn_detail_t :: enum u32 {
+xcb_xkb_nkn_detail_t :: enum_flags u16 {
     KEYCODES  :: 1;
     GEOMETRY  :: 2;
     DEVICE_ID :: 4;
@@ -177,7 +177,7 @@ xcb_xkb_set_map_flags_t :: enum u32 {
     XCB_XKB_SET_MAP_FLAGS_RECOMPUTE_ACTIONS :: RECOMPUTE_ACTIONS;
 }
 
-xcb_xkb_state_part_t :: enum u32 {
+xcb_xkb_state_part_t :: enum_flags u16 {
     MODIFIER_STATE     :: 1;
     MODIFIER_BASE      :: 2;
     MODIFIER_LATCH     :: 4;
@@ -239,7 +239,7 @@ xcb_xkb_bool_ctrl_t :: enum u32 {
     XCB_XKB_BOOL_CTRL_IGNORE_GROUP_LOCK_MASK :: IGNORE_GROUP_LOCK_MASK;
 }
 
-xcb_xkb_control_t :: enum u32 {
+xcb_xkb_control_t :: enum_flags u32 {
     GROUPS_WRAP      :: 134217728;
     INTERNAL_MODS    :: 268435456;
     IGNORE_LOCK_MODS :: 536870912;
@@ -1682,12 +1682,12 @@ xcb_xkb_use_extension_reply_t :: struct {
 }
 
 xcb_xkb_select_events_details_t :: struct {
-    affectNewKeyboard:     u16;
-    newKeyboardDetails:    u16;
-    affectState:           u16;
-    stateDetails:          u16;
-    affectCtrls:           u32;
-    ctrlDetails:           u32;
+    affectNewKeyboard:     xcb_xkb_nkn_detail_t;
+    newKeyboardDetails:    xcb_xkb_nkn_detail_t;
+    affectState:           xcb_xkb_state_part_t;
+    stateDetails:          xcb_xkb_state_part_t;
+    affectCtrls:           xcb_xkb_control_t;
+    ctrlDetails:           xcb_xkb_control_t;
     affectIndicatorState:  u32;
     indicatorStateDetails: u32;
     affectIndicatorMap:    u32;
@@ -1711,11 +1711,11 @@ xcb_xkb_select_events_request_t :: struct {
     minor_opcode: u8;
     length:       u16;
     deviceSpec:   xcb_xkb_device_spec_t;
-    affectWhich:  u16;
-    clear:        u16;
-    selectAll:    u16;
-    affectMap:    u16;
-    map:          u16;
+    affectWhich:  xcb_xkb_event_type_t;
+    clear:        xcb_xkb_event_type_t;
+    selectAll:    xcb_xkb_event_type_t;
+    affectMap:    xcb_xkb_map_part_t;
+    map:          xcb_xkb_map_part_t;
 }
 
 xcb_xkb_bell_request_t :: struct {
@@ -2941,10 +2941,10 @@ XCB_XKB_Symbols :: struct #type_info_procedures_are_void_pointers #type_info_no_
     select_events_details_unpack:                                          #type (_buffer: *void, affectWhich: u16, clear: u16, selectAll: u16, _aux: *xcb_xkb_select_events_details_t) -> s32 #c_call;
     select_events_details_sizeof:                                          #type (_buffer: *void, affectWhich: u16, clear: u16, selectAll: u16) -> s32 #c_call;
     select_events_sizeof:                                                  #type (_buffer: *void) -> s32 #c_call;
-    select_events_checked:                                                 #type (c: *xcb_connection_t, deviceSpec: xcb_xkb_device_spec_t, affectWhich: u16, clear: u16, selectAll: u16, affectMap: u16, map: u16, details: *void) -> xcb_void_cookie_t #c_call;
-    select_events:                                                         #type (c: *xcb_connection_t, deviceSpec: xcb_xkb_device_spec_t, affectWhich: u16, clear: u16, selectAll: u16, affectMap: u16, map: u16, details: *void) -> xcb_void_cookie_t #c_call;
-    select_events_aux_checked:                                             #type (c: *xcb_connection_t, deviceSpec: xcb_xkb_device_spec_t, affectWhich: u16, clear: u16, selectAll: u16, affectMap: u16, map: u16, details: *xcb_xkb_select_events_details_t) -> xcb_void_cookie_t #c_call;
-    select_events_aux:                                                     #type (c: *xcb_connection_t, deviceSpec: xcb_xkb_device_spec_t, affectWhich: u16, clear: u16, selectAll: u16, affectMap: u16, map: u16, details: *xcb_xkb_select_events_details_t) -> xcb_void_cookie_t #c_call;
+    select_events_checked:                                                 #type (c: *xcb_connection_t, deviceSpec: xcb_xkb_device_spec_t, affectWhich: xcb_xkb_event_type_t, clear: xcb_xkb_event_type_t, selectAll: xcb_xkb_event_type_t, affectMap: xcb_xkb_map_part_t, map: xcb_xkb_map_part_t, details: *void) -> xcb_void_cookie_t #c_call;
+    select_events:                                                         #type (c: *xcb_connection_t, deviceSpec: xcb_xkb_device_spec_t, affectWhich: xcb_xkb_event_type_t, clear: xcb_xkb_event_type_t, selectAll: xcb_xkb_event_type_t, affectMap: xcb_xkb_map_part_t, map: xcb_xkb_map_part_t, details: *void) -> xcb_void_cookie_t #c_call;
+    select_events_aux_checked:                                             #type (c: *xcb_connection_t, deviceSpec: xcb_xkb_device_spec_t, affectWhich: xcb_xkb_event_type_t, clear: xcb_xkb_event_type_t, selectAll: xcb_xkb_event_type_t, affectMap: xcb_xkb_map_part_t, map: xcb_xkb_map_part_t, details: *xcb_xkb_select_events_details_t) -> xcb_void_cookie_t #c_call;
+    select_events_aux:                                                     #type (c: *xcb_connection_t, deviceSpec: xcb_xkb_device_spec_t, affectWhich: xcb_xkb_event_type_t, clear: xcb_xkb_event_type_t, selectAll: xcb_xkb_event_type_t, affectMap: xcb_xkb_map_part_t, map: xcb_xkb_map_part_t, details: *xcb_xkb_select_events_details_t) -> xcb_void_cookie_t #c_call;
     select_events_details:                                                 #type (R: *xcb_xkb_select_events_request_t) -> *void #c_call;
     bell_checked:                                                          #type (c: *xcb_connection_t, deviceSpec: xcb_xkb_device_spec_t, bellClass: xcb_xkb_bell_class_spec_t, bellID: xcb_xkb_id_spec_t, percent: s8, forceSound: u8, eventOnly: u8, pitch: s16, duration: s16, name: xcb_atom_t, window: xcb_window_t) -> xcb_void_cookie_t #c_call;
     bell:                                                                  #type (c: *xcb_connection_t, deviceSpec: xcb_xkb_device_spec_t, bellClass: xcb_xkb_bell_class_spec_t, bellID: xcb_xkb_id_spec_t, percent: s8, forceSound: u8, eventOnly: u8, pitch: s16, duration: s16, name: xcb_atom_t, window: xcb_window_t) -> xcb_void_cookie_t #c_call;


### PR DESCRIPTION
Made xcb-related bindings more typesafe which allows for removing some autocasts. It's possible to get rid of more but it's a bit tricker to generate correct bindings, need to massage the generator a bit more for it